### PR TITLE
fix: close #38, export Render, fix typo, upgrade rollup-plugin-typecript2

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "prettier-tslint": "^0.4.0",
     "rollup": "^1.1.0",
     "rollup-plugin-auto-external": "^2.0.0",
-    "rollup-plugin-typescript2": "^0.17.0",
+    "rollup-plugin-typescript2": "^0.19.0",
     "ts-jest": "^23.10.1",
     "tslint": "^5.11.0",
     "tslint-plugin-prettier": "^2.0.0",

--- a/packages/markdown-render/lib/index.ts
+++ b/packages/markdown-render/lib/index.ts
@@ -23,7 +23,7 @@ export interface RenderResult {
   methods?: string
 }
 
-export default class Render {
+export class Render {
   constructor(
     public parserResult: ParserResult,
     public options?: RenderOptions
@@ -231,3 +231,5 @@ export default class Render {
     return renderMarkdown(this.render(), this.parserResult)
   }
 }
+
+export default Render

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,7 @@ function resolveInput(projectDir) {
   return path.resolve('packages', `${projectDir}/lib/index.ts`)
 }
 
-function resolveOnput(projectDir) {
+function resolveOutput(projectDir) {
   return path.resolve('packages', `${projectDir}/dist/index.js`)
 }
 
@@ -28,8 +28,9 @@ export default {
     })
   ],
   output: {
-    file: resolveOnput(PKG_DIR),
-    format: 'cjs'
+    file: resolveOutput(PKG_DIR),
+    format: 'cjs',
+    exports: 'named'
   },
   onwarn(warning, warn) {
     if (warning.code === 'UNRESOLVED_IMPORT' && isBuiltinModule(warning.source))

--- a/yarn.lock
+++ b/yarn.lock
@@ -3080,10 +3080,10 @@ fs-exists-sync@^0.1.0:
   resolved "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
   integrity sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=
 
-fs-extra@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz#8cc3f47ce07ef7b3593a11b9fb245f7e34c041d6"
-  integrity sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==
+fs-extra@7.0.1, fs-extra@^7.0.0, fs-extra@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -3102,15 +3102,6 @@ fs-extra@^4.0.1:
   version "4.0.3"
   resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
   integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
-fs-extra@^7.0.0, fs-extra@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
-  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -6945,12 +6936,12 @@ rollup-plugin-auto-external@^2.0.0:
     safe-resolve "^1.0.0"
     semver "^5.5.0"
 
-rollup-plugin-typescript2@^0.17.0:
-  version "0.17.2"
-  resolved "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.17.2.tgz#7d18a94b74993307ec69b7c2f571c12b51561a14"
-  integrity sha512-QmrZElI+p4sytmv1S7uvtUbL4XADWWmM/dIuc3agGZTE+fO2X1KoRo8EbeR1x0ZO4I9KwPubGfmw/1rHeUR+Dg==
+rollup-plugin-typescript2@^0.19.0:
+  version "0.19.2"
+  resolved "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.19.2.tgz#87d9c799cd6e02efbedbba25af12753a1e92b6c2"
+  integrity sha512-DRG7SaYX0QzBIz6rII5nm1UkiceS95r8mJjujugybyIueNF3auvzGTHMK62O7As/0q5RHjXsOguWOUv+KJKLFA==
   dependencies:
-    fs-extra "7.0.0"
+    fs-extra "7.0.1"
     resolve "1.8.1"
     rollup-pluginutils "2.3.3"
     tslib "1.9.3"


### PR DESCRIPTION
1. add `export Render` to avoid ts-check error

```js
// CommonJs
const { Render } = require('@vuese/markdown-render')
// OR
const Render = require('@vuese/markdown-render').default

// Es Module
import Render from '@vuese/markdown-render'
// OR
import { Render } from '@vuese/markdown-render'
```

2. upgrade rollup-plugin-typecript2 to ^0.19.0

https://github.com/ezolenko/rollup-plugin-typescript2/issues/126
