### PR TITLE
feat: 🎸 Allow empty Components to be rendered at will

### DIFF
--- a/packages/markdown-render/__test__/__snapshots__/index.test.ts.snap
+++ b/packages/markdown-render/__test__/__snapshots__/index.test.ts.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Empty Components (without slots,methods,props,events) can be forced to be rendered Does render an empty component by with @vuese in the description 1`] = `
+Object {
+  "componentName": "MyComponent",
+  "content": "# MyComponent
+
+This is a description of the component
+
+",
+}
+`;
+
+exports[`Empty Components (without slots,methods,props,events) can be forced to be rendered Does render an empty component by with @vuese in the description 2`] = `Object {}`;
+
 exports[`Proper rendering of the table header 1`] = `
 Object {
   "events": "|Event Name|Description|Parameters|

--- a/packages/markdown-render/__test__/index.test.ts
+++ b/packages/markdown-render/__test__/index.test.ts
@@ -49,3 +49,34 @@ test('Proper rendering of the table header', () => {
   expect(renderRes).toMatchSnapshot()
   expect(markdownRes).toMatchSnapshot()
 })
+
+describe('Empty Components (without slots,methods,props,events) can be forced to be rendered', () => {
+  test('Does not render an empty component by defaut', () => {
+    const res: ParserResult = {
+      name: 'MyComponent',
+      componentDesc: {
+        default: ['This is a description of the component']
+      }
+    }
+    const render = new Render(res)
+    const renderRes: RenderResult = render.render()
+    const markdownRes = render.renderMarkdown() as MarkdownResult
+    expect(markdownRes).toBeNull()
+    expect(renderRes).toEqual({})
+  })
+  test('Does render an empty component by with @vuese in the description', () => {
+    const res: ParserResult = {
+      name: 'MyComponent',
+      componentDesc: {
+        default: ['This is a description of the component'],
+        vuese: ['']
+      }
+    }
+    const render = new Render(res)
+    const renderRes: RenderResult = render.render()
+    const markdownRes = render.renderMarkdown() as MarkdownResult
+    expect(markdownRes).not.toBeNull()
+    expect(markdownRes).toMatchSnapshot()
+    expect(renderRes).toMatchSnapshot()
+  })
+})

--- a/packages/markdown-render/lib/genMarkdownTpl.ts
+++ b/packages/markdown-render/lib/genMarkdownTpl.ts
@@ -7,6 +7,7 @@ export default function(parserRes: ParserResult) {
   if (desc && desc.default.length) {
     templateStr += `${desc.default.join('')}\n\n`
   }
+  const forceGenerate = desc && desc.vuese && parserRes.name
   const original = templateStr
 
   templateStr += parserRes.props ? genBaseTemplate('props') : ''
@@ -14,7 +15,7 @@ export default function(parserRes: ParserResult) {
   templateStr += parserRes.slots ? genBaseTemplate('slots') : ''
   templateStr += parserRes.methods ? genBaseTemplate('methods') : ''
 
-  return original === templateStr ? '' : templateStr
+  return !forceGenerate && original === templateStr ? '' : templateStr
 }
 
 function genBaseTemplate(label: string) {


### PR DESCRIPTION
Sometimes it can be wished that components are still included, although
they have no slots, methods, props or events. Right now, they are not rendered under these circumstances.
Adding the key `@vuese` to the component description will lead to the component being included in
the resulting documentation.

Like so 
```
/*
 * @vuese
 * This component is empty and will be still rendered
 */
export default { ... }
```