### PR TITLE
feat: 🎸 Add Ability to Group Components

### DIFF
--- a/packages/cli/lib/genDocute.ts
+++ b/packages/cli/lib/genDocute.ts
@@ -10,17 +10,13 @@ export default async (config: CliOptions) => {
   try {
     const componentsPromise = await genMarkdown(config)
     const componentRes = await Promise.all(componentsPromise)
-    const componentNames = componentRes
-      .filter(_ => _)
-      .map((res: any) => {
-        return res.compName
-      })
+    const components = componentRes.filter(_ => _)
     logger.progress('Start generating...')
     await sao({
       template: path.resolve(__dirname, './templates/docute'),
       targetPath: path.resolve(config.outDir as string),
       configOptions: {
-        componentNames,
+        components,
         title: config.title,
         markdownDir: config.markdownDir
       }

--- a/packages/cli/lib/genMarkdown.ts
+++ b/packages/cli/lib/genMarkdown.ts
@@ -41,6 +41,7 @@ export default async (config: CliOptions) => {
       let compName = markdownRes.componentName
         ? markdownRes.componentName
         : path.basename(abs, '.vue')
+      const groupName = markdownRes.groupName
 
       str = str.replace(/\[name\]/g, compName)
       let targetDir = ''
@@ -63,6 +64,7 @@ export default async (config: CliOptions) => {
 
       return {
         compName,
+        groupName,
         content: str
       }
     } catch (e) {

--- a/packages/cli/lib/templates/docute/sao.js
+++ b/packages/cli/lib/templates/docute/sao.js
@@ -1,10 +1,34 @@
 module.exports = options => {
-  const { title, componentNames, markdownDir } = options
+  const { title, components, markdownDir } = options
+  const groupsObjs = {}
+  const groups = []
+  components.forEach(c => {
+    const res = {
+      title: c.compName,
+      link: '/' + markdownDir + '/' + c.compName
+    }
+    if (groupsObjs[c.groupName]) {
+      groupsObjs[c.groupName].push(res)
+    } else {
+      groupsObjs[c.groupName] = [res]
+    }
+  })
+  Object.keys(groupsObjs).forEach(name => {
+    groups.push({
+      title: name,
+      links: groupsObjs[name].sort((a, b) => a.name > b.name ? 1 : -1)
+    })
+  })
+  groups.sort((a, b) => {
+    if (a.title === '') return -1
+    if (b.title === '') return 1
+    return a.name > b.name ? 1 : -1
+  })
   const config = {
     data(answers) {
       return {
         title: title || answers.title,
-        componentNames,
+        groupsStr: JSON.stringify(groups),
         markdownDir
       }
     }

--- a/packages/cli/lib/templates/docute/sao.js
+++ b/packages/cli/lib/templates/docute/sao.js
@@ -16,7 +16,7 @@ module.exports = options => {
   Object.keys(groupsObjs).forEach(name => {
     groups.push({
       title: name,
-      links: groupsObjs[name].sort((a, b) => a.name > b.name ? 1 : -1)
+      links: groupsObjs[name].sort((a, b) => (a.name > b.name ? 1 : -1))
     })
   })
   groups.sort((a, b) => {

--- a/packages/cli/lib/templates/docute/template/index.html
+++ b/packages/cli/lib/templates/docute/template/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>My Docs</title>
+    <title><%= title %></title>
     <link rel="stylesheet" href="https://unpkg.com/docute@4/dist/docute.css">
   </head>
   <body>
@@ -12,19 +12,7 @@
     <script>
       new Docute({
         target: '#docute',
-        sidebar: [
-          {
-            title: '<%= title %>',
-            links: [
-              <% for (var i = 0; i < componentNames.length; i++) { %>
-                {
-                  title: '<%= componentNames[i] %>',
-                  link: '/<%= markdownDir %>/<%= componentNames[i] %>'
-                }<% if (i !== componentNames.length - 1) { %>,<% } %>
-              <% } %>
-            ]
-          }
-        ]
+        sidebar: JSON.parse('<%= groupsStr %>'.replace(/\&\#34\;/g, '"'))
       })
     </script>
   </body>

--- a/packages/markdown-render/__test__/__snapshots__/index.test.ts.snap
+++ b/packages/markdown-render/__test__/__snapshots__/index.test.ts.snap
@@ -69,5 +69,6 @@ This is a description of the component
 
 
 ",
+  "groupName": "My Group",
 }
 `;

--- a/packages/markdown-render/__test__/index.test.ts
+++ b/packages/markdown-render/__test__/index.test.ts
@@ -5,7 +5,8 @@ test('Proper rendering of the table header', () => {
   const res: ParserResult = {
     name: 'MyComponent',
     componentDesc: {
-      default: ['This is a description of the component']
+      default: ['This is a description of the component'],
+      group: ['My Group']
     },
     props: [
       {

--- a/packages/markdown-render/lib/renderMarkdown.ts
+++ b/packages/markdown-render/lib/renderMarkdown.ts
@@ -8,6 +8,7 @@ const htmlCommentRE = /<!--\s*@vuese:([a-zA-Z_][\w\-\.]*|\[name\]):(\w+):start\s
 export interface MarkdownResult {
   content: string
   componentName: string
+  groupName: string
 }
 
 export default function(
@@ -21,6 +22,10 @@ export default function(
 
   let str = mdTemplate
   let compName = parserRes.name
+  const groupName =
+    parserRes.componentDesc && parserRes.componentDesc.group
+      ? parserRes.componentDesc.group[0]
+      : undefined
 
   if (compName) {
     str = mdTemplate.replace(nameRE, compName)
@@ -57,6 +62,7 @@ export default function(
 
   return {
     content: str,
-    componentName: compName || ''
+    componentName: compName || '',
+    groupName: groupName || ''
   }
 }

--- a/packages/markdown-render/lib/renderMarkdown.ts
+++ b/packages/markdown-render/lib/renderMarkdown.ts
@@ -63,6 +63,6 @@ export default function(
   return {
     content: str,
     componentName: compName || '',
-    groupName: groupName || ''
+    groupName: groupName || 'BASIC'
   }
 }


### PR DESCRIPTION
Allow Components to be grouped by adding the `@group` argument to the
component description

For Example: 
```
/* 
 * @group Pages
 * Renders the Home Page
 */
export default { name: 'HomePage' }
```

<img width="1095" alt="bildschirmfoto 2019-02-17 um 22 16 51" src="https://user-images.githubusercontent.com/17594215/52919336-6092f500-32f9-11e9-87fd-276c8925a3ba.png">
