### PR TITLE
:beetle: (parser) Gets correct name for a quoted property

### DIFF
--- a/packages/parser/lib/parseJavascript.ts
+++ b/packages/parser/lib/parseJavascript.ts
@@ -52,7 +52,10 @@ export function parseJavascript(ast: bt.File, options: ParserOptions = {}) {
                 ObjectProperty(propPath: NodePath<bt.ObjectProperty>) {
                   // Guarantee that this is the prop definition
                   if (propPath.parentPath === valuePath) {
-                    const name = propPath.node.key.name
+                    const name =
+                      propPath.node.key.type === 'Identifier'
+                        ? propPath.node.key.name
+                        : propPath.node.key.value
                     const propValueNode = propPath.node.value
                     const result: PropsResult = {
                       name,


### PR DESCRIPTION
If a prop name was enclosed in quotes then the documentation read 'undefined' - detect if prop is an
identifier or a literal

Closes #47