### PR TITLE
:beetle: (parser) Ignore computed when it's a callable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 *.txt
 test-website
 .profile
+yarn.lock

--- a/packages/parser/lib/parseJavascript.ts
+++ b/packages/parser/lib/parseJavascript.ts
@@ -94,7 +94,11 @@ export function parseJavascript(ast: bt.File, options: ParserOptions = {}) {
           }
 
           // Processing computed
-          if (onComputed && isVueOption(path, 'computed')) {
+          if (
+            onComputed &&
+            isVueOption(path, 'computed') &&
+            bt.isObjectExpression(path.node.value)
+          ) {
             const properties = (path.node
               .value as bt.ObjectExpression).properties.filter(
               n => bt.isObjectMethod(n) || bt.isObjectProperty(n)


### PR DESCRIPTION
When computed is a callable, eg when using mapGetters, it crashed as it was expecting an object -
check to see if it's an object first

Closes #59