### PR TITLE
Add markdownFile config

### DIFF
--- a/packages/cli/lib/genMarkdown.ts
+++ b/packages/cli/lib/genMarkdown.ts
@@ -14,6 +14,7 @@ export default async (config: CliOptions) => {
     exclude,
     outDir,
     markdownDir,
+    markdownFile,
     babelParserPlugins,
     isPreview,
     genType
@@ -45,16 +46,19 @@ export default async (config: CliOptions) => {
 
       str = str.replace(/\[name\]/g, compName)
       let targetDir = ''
+      let targetFile = ''
       if (genType === 'markdown' && markdownDir === '*') {
         targetDir = path.dirname(abs)
+        targetFile = markdownFile || compName
       } else {
         targetDir = path.resolve(
           outDir,
           markdownDir === '*' ? 'components' : markdownDir
         )
+        targetFile = compName
       }
 
-      const target = path.resolve(targetDir, compName + '.md')
+      const target = path.resolve(targetDir, targetFile + '.md')
 
       if (!isPreview) {
         await fs.ensureDir(targetDir)

--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -26,6 +26,7 @@ export type CliOptions = {
   exclude: string | string[]
   outDir: string
   markdownDir: string
+  markdownFile: string
   genType: 'docute' | 'markdown'
   title: string
   babelParserPlugins: BabelParserPlugins
@@ -46,7 +47,8 @@ async function getConfig(flags: PartialCliOptions) {
     include: '**/*.vue',
     exclude: [],
     outDir: 'website',
-    markdownDir: 'components'
+    markdownDir: 'components',
+    markdownFile: ''
   }
   if (path) Object.assign(config, data, flags)
   Object.assign(config, flags || {})


### PR DESCRIPTION
Add **`markdownFile`** cli config parameter for markdown type if `markdownDir` is `*`.

It is useful when I'd like to name all the doc files, e.g. `README.md`.

Example config:
```json
{
  "genType": "markdown",
  "include": ["src/components/**/index.vue"],
  "markdownDir": "*",
  "markdownFile": "README"
}
```
