### PR TITLE
cli(preview): fix preview file path

### DIFF
--- a/packages/cli/lib/preview.ts
+++ b/packages/cli/lib/preview.ts
@@ -11,7 +11,7 @@ import { CliOptions } from '.'
 const logger = Log.create()
 
 export default async (config: CliOptions) => {
-  const sfc = (config.include as string[])[0]
+  const sfc = config.include as string
   if (!sfc) {
     logger.error('Must provide the path to the .vue file.')
     process.exit(1)


### PR DESCRIPTION
```js
cli.command('preview [file]')
```

`file` is not an `Array`

Finally figure out why nothing happened with command `preview` 😂