### PR TITLE
Multiple params and line break support for methods and events

### DIFF
--- a/packages/markdown-render/__test__/__snapshots__/index.test.ts.snap
+++ b/packages/markdown-render/__test__/__snapshots__/index.test.ts.snap
@@ -16,14 +16,8 @@ exports[`Empty Components (without slots,methods,props,events) can be forced to 
 
 exports[`Proper rendering of the table header 1`] = `
 Object {
-  "events": "|Event Name|Description|Parameters|
-|---|---|---|
-|click|Triggered when clicked|a boolean value|
-",
-  "methods": "|Method|Description|Parameters|
-|---|---|---|
-|clear|Clear form|a boolean value|
-",
+  "events": "<table><thead><tr><th>Event Name</th><th>Description</th><th>Parameters</th><th>Type</th><th>Default</th></tr></thead><tbody><tr><td rowspan=1>click</td><td rowspan=1>Triggered when clicked</td><td rowspan=1>test</td><td rowspan=1>Boolean</td><td rowspan=1>false</td></tr></tbody></table>",
+  "methods": "<table><thead><tr><th>Method</th><th>Description</th><th>Parameters</th><th>Type</th><th>Default</th></tr></thead><tbody><tr><td rowspan=1>clear</td><td rowspan=1>Clear form</td><td rowspan=1>test</td><td rowspan=1>Boolean</td><td rowspan=1>false</td></tr></tbody></table>",
   "props": "|Name|Description|Type|Required|Default|
 |---|---|---|---|---|
 |someProp|Represents the direction of the arrow|\`TOP\` / \`BOTTOM\`|\`true\`|\`TOP\`|
@@ -55,10 +49,7 @@ This is a description of the component
 ## Events
 
 <!-- @vuese:MyComponent:events:start -->
-|Event Name|Description|Parameters|
-|---|---|---|
-|click|Triggered when clicked|a boolean value|
-
+<table><thead><tr><th>Event Name</th><th>Description</th><th>Parameters</th><th>Type</th><th>Default</th></tr></thead><tbody><tr><td rowspan=1>click</td><td rowspan=1>Triggered when clicked</td><td rowspan=1>test</td><td rowspan=1>Boolean</td><td rowspan=1>false</td></tr></tbody></table>
 <!-- @vuese:MyComponent:events:end -->
 
 
@@ -75,10 +66,7 @@ This is a description of the component
 ## Methods
 
 <!-- @vuese:MyComponent:methods:start -->
-|Method|Description|Parameters|
-|---|---|---|
-|clear|Clear form|a boolean value|
-
+<table><thead><tr><th>Method</th><th>Description</th><th>Parameters</th><th>Type</th><th>Default</th></tr></thead><tbody><tr><td rowspan=1>clear</td><td rowspan=1>Clear form</td><td rowspan=1>test</td><td rowspan=1>Boolean</td><td rowspan=1>false</td></tr></tbody></table>
 <!-- @vuese:MyComponent:methods:end -->
 
 

--- a/packages/markdown-render/__test__/index.test.ts
+++ b/packages/markdown-render/__test__/index.test.ts
@@ -24,7 +24,14 @@ test('Proper rendering of the table header', () => {
         isSync: false,
         syncProp: '',
         describe: ['Triggered when clicked'],
-        argumentsDesc: ['a boolean value']
+        argumentsDesc: [
+          {
+            name: 'test',
+            type: 'Boolean',
+            default: 'false',
+            description: 'a boolean value'
+          }
+        ]
       }
     ],
     slots: [
@@ -40,13 +47,21 @@ test('Proper rendering of the table header', () => {
       {
         name: 'clear',
         describe: ['Clear form'],
-        argumentsDesc: ['a boolean value']
+        argumentsDesc: [
+          {
+            name: 'test',
+            type: 'Boolean',
+            default: 'false',
+            description: 'a boolean value'
+          }
+        ]
       }
     ]
   }
   const render = new Render(res)
   const renderRes: RenderResult = render.render()
   const markdownRes = render.renderMarkdown() as MarkdownResult
+  console.log(renderRes)
   expect(renderRes).toMatchSnapshot()
   expect(markdownRes).toMatchSnapshot()
 })

--- a/packages/markdown-render/lib/index.ts
+++ b/packages/markdown-render/lib/index.ts
@@ -38,9 +38,9 @@ export class Render {
       {},
       {
         props: ['Name', 'Description', 'Type', 'Required', 'Default'],
-        events: ['Event Name', 'Description', 'Parameters'],
+        events: ['Event Name', 'Description', 'Parameters', 'Type', 'Default'],
         slots: ['Name', 'Description', 'Default Slot Content'],
-        methods: ['Method', 'Description', 'Parameters'],
+        methods: ['Method', 'Description', 'Parameters', 'Type', 'Default'],
         computed: ['Computed', 'Description'],
         mixIns: ['MixIn']
       },
@@ -172,62 +172,130 @@ export class Render {
 
   eventRender(propsRes: EventResult[]) {
     const eventConfig = (this.options as RenderOptions).events
-    let code = this.renderTabelHeader(eventConfig)
+
+    const codes = ['<table><thead><tr>']
+
+    codes.push(eventConfig.map(name => `<th>${name}</th>`).join(''))
+    codes.push('</tr></thead><tbody>')
+
+    function cellCode(content: String | undefined, rowspan: Number) {
+      rowspan = rowspan || 1
+      return `<td rowspan=${rowspan}>${content || '-'}</td>`
+    }
     propsRes.forEach((event: EventResult) => {
-      const row: string[] = []
+      const rowCodes = ['<tr>']
+
+      const argumentsDesc = event.argumentsDesc || []
+      const argLength = argumentsDesc.length
+
       for (let i = 0; i < eventConfig.length; i++) {
-        if (eventConfig[i] === 'Event Name') {
-          row.push(event.name)
-        } else if (eventConfig[i] === 'Description') {
-          if (event.describe && event.describe.length) {
-            row.push(event.describe.join(''))
-          } else {
-            row.push('-')
-          }
-        } else if (eventConfig[i] === 'Parameters') {
-          if (event.argumentsDesc) {
-            row.push(event.argumentsDesc.join(''))
-          } else {
-            row.push('-')
-          }
-        } else {
-          row.push('-')
+        const paramed = argLength > 0
+        switch (eventConfig[i]) {
+          case 'Event Name':
+            rowCodes.push(cellCode(event.name, argLength))
+            break
+          case 'Description':
+            const descripted = event.describe && event.describe.length
+            rowCodes.push(
+              cellCode(
+                descripted ? (event.describe || []).join('<br>') : '-',
+                descripted ? argLength : 1
+              )
+            )
+            break
+          case 'Parameters':
+            rowCodes.push(cellCode(paramed ? argumentsDesc[0].name : '-', 1))
+            break
+          case 'Type':
+            rowCodes.push(cellCode(paramed ? argumentsDesc[0].type : '-', 1))
+            break
+          case 'Default':
+            rowCodes.push(cellCode(paramed ? argumentsDesc[0].default : '-', 1))
+            break
+          default:
+            rowCodes.push(cellCode('-', argLength))
+            break
         }
       }
-      code += this.renderTabelRow(row)
-    })
 
-    return code
+      let argCursor = 1
+      while (argCursor < argLength) {
+        rowCodes.push('</tr><tr>')
+        rowCodes.push(cellCode(argumentsDesc[argCursor].name, 1))
+        rowCodes.push(cellCode(argumentsDesc[argCursor].type, 1))
+        rowCodes.push(cellCode(argumentsDesc[argCursor].default, 1))
+        argCursor++
+      }
+      rowCodes.push('</tr>')
+
+      codes.push(rowCodes.join(''))
+    })
+    codes.push('</tbody></table>')
+    return codes.join('')
   }
 
   methodRender(methodsRes: MethodResult[]) {
     const methodConfig = (this.options as RenderOptions).methods
-    let code = this.renderTabelHeader(methodConfig)
+
+    const codes = ['<table><thead><tr>']
+
+    codes.push(methodConfig.map(name => `<th>${name}</th>`).join(''))
+    codes.push('</tr></thead><tbody>')
+
+    function cellCode(content: String | undefined, rowspan: Number) {
+      rowspan = rowspan || 1
+      return `<td rowspan=${rowspan}>${content || '-'}</td>`
+    }
     methodsRes.forEach((method: MethodResult) => {
-      const row: string[] = []
+      const rowCodes = ['<tr>']
+
+      const argumentsDesc = method.argumentsDesc || []
+      const argLength = argumentsDesc.length
+
       for (let i = 0; i < methodConfig.length; i++) {
-        if (methodConfig[i] === 'Method') {
-          row.push(method.name)
-        } else if (methodConfig[i] === 'Description') {
-          if (method.describe) {
-            row.push(method.describe.join(''))
-          } else {
-            row.push('-')
-          }
-        } else if (methodConfig[i] === 'Parameters') {
-          if (method.argumentsDesc) {
-            row.push(method.argumentsDesc.join(''))
-          } else {
-            row.push('-')
-          }
-        } else {
-          row.push('-')
+        const paramed = argLength > 0
+
+        switch (methodConfig[i]) {
+          case 'Method':
+            rowCodes.push(cellCode(method.name, argLength))
+            break
+          case 'Description':
+            const descripted = method.describe && method.describe.length
+            rowCodes.push(
+              cellCode(
+                descripted ? (method.describe || []).join('<br>') : '-',
+                descripted ? argLength : 1
+              )
+            )
+            break
+          case 'Parameters':
+            rowCodes.push(cellCode(paramed ? argumentsDesc[0].name : '-', 1))
+            break
+          case 'Type':
+            rowCodes.push(cellCode(paramed ? argumentsDesc[0].type : '-', 1))
+            break
+          case 'Default':
+            rowCodes.push(cellCode(paramed ? argumentsDesc[0].default : '-', 1))
+            break
+          default:
+            rowCodes.push(cellCode('-', argLength))
+            break
         }
       }
-      code += this.renderTabelRow(row)
-    })
+      let argCursor = 1
+      while (argCursor < argLength) {
+        rowCodes.push('</tr><tr>')
+        rowCodes.push(cellCode(argumentsDesc[argCursor].name, 1))
+        rowCodes.push(cellCode(argumentsDesc[argCursor].type, 1))
+        rowCodes.push(cellCode(argumentsDesc[argCursor].default, 1))
+        argCursor++
+      }
+      rowCodes.push('</tr>')
 
-    return code
+      codes.push(rowCodes.join(''))
+    })
+    codes.push('</tbody></table>')
+    return codes.join('')
   }
 
   computedRender(computedRes: ComputedResult[]) {

--- a/packages/parser/__test__/__snapshots__/parseJavascript.test.ts.snap
+++ b/packages/parser/__test__/__snapshots__/parseJavascript.test.ts.snap
@@ -12,7 +12,9 @@ Array [
 
 exports[`@Emit decorator 2`] = `
 Array [
-  "The argument is a boolean value representing xxx",
+  ArgumentDelaration {
+    "description": "The argument is a boolean value representing xxx",
+  },
 ]
 `;
 
@@ -36,7 +38,9 @@ Array [
 
 exports[`Class method 2`] = `
 Array [
-  "The first parameter is a Boolean value that represents...",
+  ArgumentDelaration {
+    "description": "The first parameter is a Boolean value that represents...",
+  },
 ]
 `;
 
@@ -48,7 +52,9 @@ Array [
 
 exports[`Correct handling of events 2`] = `
 Array [
-  "The first parameter is a Boolean value that represents...",
+  ArgumentDelaration {
+    "description": "The first parameter is a Boolean value that represents...",
+  },
 ]
 `;
 
@@ -64,7 +70,9 @@ Array [
 
 exports[`Correct handling of methods 2`] = `
 Array [
-  "The first parameter is a Boolean value that represents...",
+  ArgumentDelaration {
+    "description": "The first parameter is a Boolean value that represents...",
+  },
 ]
 `;
 
@@ -165,7 +173,9 @@ Array [
 
 exports[`The options in @Component should be parsed correctly 2`] = `
 Array [
-  "The first parameter is a Boolean value that represents...",
+  ArgumentDelaration {
+    "description": "The first parameter is a Boolean value that represents...",
+  },
 ]
 `;
 
@@ -177,7 +187,9 @@ Array [
 
 exports[`The options in @Component should be parsed correctly 4`] = `
 Array [
-  "The argument is a boolean value representing xxx",
+  ArgumentDelaration {
+    "description": "The argument is a boolean value representing xxx",
+  },
 ]
 `;
 

--- a/packages/parser/__test__/parseJavascript.test.ts
+++ b/packages/parser/__test__/parseJavascript.test.ts
@@ -5,7 +5,8 @@ import {
   EventResult,
   MethodResult,
   SlotResult,
-  MixInResult
+  MixInResult,
+  ArgumentDelaration
 } from '@vuese/parser'
 import * as path from 'path'
 import * as fs from 'fs'
@@ -214,7 +215,9 @@ test('Correct handling of events', () => {
   expect(mockOnEvent.mock.calls.length).toBe(2)
   expect((arg1 as EventResult).name).toBe('click')
   expect(((arg1 as EventResult).describe as string[]).length).toBe(1)
-  expect(((arg1 as EventResult).argumentsDesc as string[]).length).toBe(1)
+  expect(
+    ((arg1 as EventResult).argumentsDesc as ArgumentDelaration[]).length
+  ).toBe(1)
   expect((arg1 as EventResult).describe).toMatchSnapshot()
   expect((arg1 as EventResult).argumentsDesc).toMatchSnapshot()
 
@@ -251,7 +254,9 @@ test('Correct handling of methods', () => {
   expect(mockOnMethod.mock.calls.length).toBe(1)
   expect((arg as MethodResult).name).toBe('fn')
   expect(((arg as MethodResult).describe as string[]).length).toBe(1)
-  expect(((arg as MethodResult).argumentsDesc as string[]).length).toBe(1)
+  expect(
+    ((arg as MethodResult).argumentsDesc as ArgumentDelaration[]).length
+  ).toBe(1)
   expect((arg as MethodResult).describe).toMatchSnapshot()
   expect((arg as MethodResult).argumentsDesc).toMatchSnapshot()
 })
@@ -274,7 +279,9 @@ test('The options in @Component should be parsed correctly', () => {
   expect(mockOnMethod.mock.calls.length).toBe(1)
   expect((arg as MethodResult).name).toBe('clear')
   expect(((arg as MethodResult).describe as string[]).length).toBe(1)
-  expect(((arg as MethodResult).argumentsDesc as string[]).length).toBe(1)
+  expect(
+    ((arg as MethodResult).argumentsDesc as ArgumentDelaration[]).length
+  ).toBe(1)
   expect((arg as MethodResult).describe).toMatchSnapshot()
   expect((arg as MethodResult).argumentsDesc).toMatchSnapshot()
 
@@ -282,7 +289,9 @@ test('The options in @Component should be parsed correctly', () => {
   expect(mockOnEvent.mock.calls.length).toBe(1)
   expect((arg1 as EventResult).name).toBe('onclear')
   expect(((arg1 as EventResult).describe as string[]).length).toBe(1)
-  expect(((arg1 as EventResult).argumentsDesc as string[]).length).toBe(1)
+  expect(
+    ((arg1 as EventResult).argumentsDesc as ArgumentDelaration[]).length
+  ).toBe(1)
   expect((arg1 as EventResult).describe).toMatchSnapshot()
   expect((arg1 as EventResult).argumentsDesc).toMatchSnapshot()
 
@@ -337,7 +346,9 @@ test('Class method', () => {
   expect(mockOnMethod.mock.calls.length).toBe(1)
   expect((arg as MethodResult).name).toBe('someMethod')
   expect(((arg as MethodResult).describe as string[]).length).toBe(1)
-  expect(((arg as MethodResult).argumentsDesc as string[]).length).toBe(1)
+  expect(
+    ((arg as MethodResult).argumentsDesc as ArgumentDelaration[]).length
+  ).toBe(1)
   expect((arg as MethodResult).describe).toMatchSnapshot()
   expect((arg as MethodResult).argumentsDesc).toMatchSnapshot()
 })
@@ -357,7 +368,9 @@ test('@Emit decorator', () => {
   expect(mockOnEvent.mock.calls.length).toBe(3)
   expect((arg1 as EventResult).name).toBe('on-click')
   expect(((arg1 as EventResult).describe as string[]).length).toBe(1)
-  expect(((arg1 as EventResult).argumentsDesc as string[]).length).toBe(1)
+  expect(
+    ((arg1 as EventResult).argumentsDesc as ArgumentDelaration[]).length
+  ).toBe(1)
   expect((arg1 as EventResult).describe).toMatchSnapshot()
   expect((arg1 as EventResult).argumentsDesc).toMatchSnapshot()
 

--- a/packages/parser/lib/index.ts
+++ b/packages/parser/lib/index.ts
@@ -26,18 +26,25 @@ export interface PropsResult {
   describe?: string[]
 }
 
+export class ArgumentDelaration {
+  name: String | undefined
+  type: String | undefined
+  default: String | undefined
+  description: String | undefined
+}
+
 export interface EventResult {
   name: string
   isSync: boolean
   syncProp: string
   describe?: string[]
-  argumentsDesc?: string[]
+  argumentsDesc?: ArgumentDelaration[]
 }
 
 export interface MethodResult {
   name: string
   describe?: string[]
-  argumentsDesc?: string[]
+  argumentsDesc?: ArgumentDelaration[]
 }
 
 export interface ComputedResult {

--- a/packages/parser/lib/parseJavascript.ts
+++ b/packages/parser/lib/parseJavascript.ts
@@ -20,6 +20,7 @@ import {
 import { processEventName, getEmitDecorator } from './processEvents'
 import { determineChildren } from './processRenderFunction'
 import { Seen } from './seen'
+import { processArguments } from './processArguments'
 
 export function parseJavascript(ast: bt.File, options: ParserOptions = {}) {
   const seenEvent = new Seen()
@@ -131,7 +132,7 @@ export function parseJavascript(ast: bt.File, options: ParserOptions = {}) {
                 const result: MethodResult = {
                   name: node.key.name,
                   describe: commentsRes.default,
-                  argumentsDesc: commentsRes.arg
+                  argumentsDesc: processArguments(commentsRes.arg)
                 }
                 onMethod(result)
               }
@@ -242,7 +243,7 @@ export function parseJavascript(ast: bt.File, options: ParserOptions = {}) {
             const result: MethodResult = {
               name: (node.key as bt.Identifier).name,
               describe: commentsRes.default,
-              argumentsDesc: commentsRes.arg
+              argumentsDesc: processArguments(commentsRes.arg)
             }
             if (options.onMethod) options.onMethod(result)
           }

--- a/packages/parser/lib/processArguments.ts
+++ b/packages/parser/lib/processArguments.ts
@@ -1,0 +1,41 @@
+import { ArgumentDelaration } from './index'
+
+export function processArguments(
+  args: String[]
+): ArgumentDelaration[] | undefined {
+  if (!args || args.length === 0) {
+    return undefined
+  }
+  return (
+    args.map(argDec => {
+      const metaSplitter = ' - '
+      const argMetaIndex = argDec.indexOf(metaSplitter)
+      const structedArg = new ArgumentDelaration()
+
+      if (argMetaIndex <= 0) {
+        structedArg.description = argDec
+        return structedArg
+      }
+
+      let argMetaString = argDec.substr(0, argMetaIndex)
+      structedArg.description = argDec.substr(
+        argMetaIndex + metaSplitter.length
+      )
+
+      const typeRe = /{[a-z0-9]+}/gi
+      const typeName = (argMetaString.match(typeRe) || [])[0]
+      structedArg.name = typeName ? typeName.replace(/[{}]/gi, '') : undefined
+      argMetaString = argMetaString.replace(typeRe, '')
+
+      const defaultRe = /\[[a-z0-9\-\.\_]+\]/gi
+      const defaultValue = (argMetaString.match(defaultRe) || [])[0]
+      structedArg.default = defaultValue
+        ? defaultValue.replace(/[\[\]]/gi, '')
+        : undefined
+      argMetaString = argMetaString.replace(defaultRe, '')
+
+      structedArg.name = argMetaString.trim()
+      return structedArg
+    }) || []
+  )
+}

--- a/packages/parser/lib/processEvents.ts
+++ b/packages/parser/lib/processEvents.ts
@@ -2,6 +2,7 @@ import * as bt from '@babel/types'
 import { NodePath } from '@babel/traverse'
 import { EventResult } from './index'
 import { getComments, CommentResult } from './jscomments'
+import { processArguments } from './processArguments'
 
 /**
  *
@@ -29,10 +30,10 @@ export function processEventName(
     // Use the trailing comments of the prev node
     allComments = getComments(cnodePath.getSibling(prevPathKey).node, true)
     result.describe = allComments.default
-    result.argumentsDesc = allComments.arg
+    result.argumentsDesc = processArguments(allComments.arg)
   } else {
     result.describe = allComments.default
-    result.argumentsDesc = allComments.arg
+    result.argumentsDesc = processArguments(allComments.arg)
   }
 }
 


### PR DESCRIPTION
1. multiple args support for methods and events like JSDoc does. support arg type and default value
2. support multiple lines in method and event descriptions

    methods: {
        /**
         * @vuese
         * descprition first row
         * descprition second row
         * @arg argA {Boolean} [false] - argA desc
         * @arg argB {String} [foo] - argB desc
         */
        submit(argA, argB) {
            /**
             * some-event to do something
             * @arg argA {Boolean} [false] - argA desc
             * @arg argB {String} [foo] - argB desc
             */
            this.$emit('some-event', argA, argB)
        }
    }