### PR TITLE
chore: updated typings for parser

### DIFF
--- a/packages/parser/lib/index.ts
+++ b/packages/parser/lib/index.ts
@@ -12,7 +12,7 @@ export * from './jscomments'
 
 export type PropType = string | string[] | null
 
-export type BabelParserPlugins = { [key in ParserPlugin]?: boolean }
+export type BabelParserPlugins = { [key in keyof ParserPlugin]?: boolean }
 
 export interface PropsResult {
   type: PropType


### PR DESCRIPTION
The typings for parser has a mistake in it which is preventing builds.

More details on this issue here:
https://github.com/vuese/vuese/issues/60#issuecomment-478764752
