### PR TITLE
feat(chore): Adds a new command to show up local environment information

### DIFF
--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -8,6 +8,9 @@ import genDocute from './genDocute'
 import genMarkdown from './genMarkdown'
 import server from './server'
 
+// Gotta fix after https://github.com/tabrindle/envinfo/pull/105 gets merged (type-definitions)
+const envinfo = require('envinfo')
+
 const logger = Log.create()
 const cli = cac()
 const joycon = new JoyCon({
@@ -97,6 +100,22 @@ cli
   .action(async flags => {
     const config = await getConfig(flags)
     server(config as CliOptions)
+  })
+
+cli
+  .command(
+    'info',
+    'Show debugging information concerning the local environment'
+  )
+  .action(async () => {
+    logger.log('\nEnvironment Info:')
+    const data = await envinfo.run({
+      System: ['OS', 'CPU'],
+      Binaries: ['Node', 'Yarn', 'npm'],
+      Browsers: ['Chrome', 'Edge', 'Firefox', 'Safari'],
+      npmGlobalPackages: ['vuese']
+    })
+    logger.log(data)
   })
 
 cli.version(require('../package.json').version)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,6 +38,7 @@
     "cac": "^6.4.0",
     "carlo": "^0.9.10",
     "chokidar": "^2.0.4",
+    "envinfo": "^7.3.1",
     "fast-glob": "^2.2.6",
     "fs-extra": "^7.0.1",
     "get-port": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2758,6 +2758,11 @@ env-paths@^1.0.0:
   resolved "https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz#4168133b42bb05c38a35b1ae4397c8298ab369e0"
   integrity sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=
 
+envinfo@^7.3.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.3.1.tgz#892e42f7bf858b3446d9414ad240dbaf8da52f09"
+  integrity sha512-GvXiDTqLYrORVSCuJCsWHPXF5BFvoWMQA9xX4YVjPT1jyS3aZEHUBwjzxU/6LTPF9ReHgVEbX7IEN5UvSXHw/A==
+
 err-code@^1.0.0:
   version "1.1.2"
   resolved "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"


### PR DESCRIPTION
Fixes #95 

Dependent on [#105](https://github.com/tabrindle/envinfo/pull/105) (type-definitions)

## Proposed API
`vuese info`