### PR TITLE
Add ability to create docs for store.js and <mixin>.js files.

### DIFF
--- a/packages/cli/lib/genMarkdown.ts
+++ b/packages/cli/lib/genMarkdown.ts
@@ -32,7 +32,10 @@ export default async (config: CliOptions) => {
     const abs = path.resolve(p)
     const source = await fs.readFile(abs, 'utf-8')
     try {
-      const parserRes = parser(source, { babelParserPlugins })
+      const parserRes = parser(source, {
+        babelParserPlugins,
+        jsFile: abs.endsWith('.js')
+      })
       const r = new Render(parserRes)
       let markdownRes = r.renderMarkdown()
 

--- a/packages/markdown-render/__test__/__snapshots__/index.test.ts.snap
+++ b/packages/markdown-render/__test__/__snapshots__/index.test.ts.snap
@@ -14,6 +14,77 @@ This is a description of the component. Supplementary description
 
 exports[`Empty Components (without slots,methods,props,events) can be forced to be rendered Does render an empty component by with @vuese in the description 2`] = `Object {}`;
 
+exports[`Proper rendering of store 1`] = `
+Object {
+  "actions": "|Action|Description|Parameters|
+|---|---|---|
+|fetchObject|Grabs the action from the API|the url to get|
+",
+  "getters": "|Getter|Description|
+|---|---|
+|formattedObject|Returns a correctly formatted object|
+",
+  "mutations": "|Mutation|Description|Parameters|
+|---|---|---|
+|MUTATE_OBJECT|Set the object in the store|object with key/value to set|
+",
+  "state": "|Name|Description|
+|---|---|
+|stateObject|stores the object|
+",
+}
+`;
+
+exports[`Proper rendering of store 2`] = `
+Object {
+  "componentName": "Store",
+  "content": "# Store
+
+## Getters
+
+<!-- @vuese:Store:getters:start -->
+|Getter|Description|
+|---|---|
+|formattedObject|Returns a correctly formatted object|
+
+<!-- @vuese:Store:getters:end -->
+
+
+## Actions
+
+<!-- @vuese:Store:actions:start -->
+|Action|Description|Parameters|
+|---|---|---|
+|fetchObject|Grabs the action from the API|the url to get|
+
+<!-- @vuese:Store:actions:end -->
+
+
+## Mutations
+
+<!-- @vuese:Store:mutations:start -->
+|Mutation|Description|Parameters|
+|---|---|---|
+|MUTATE_OBJECT|Set the object in the store|object with key/value to set|
+
+<!-- @vuese:Store:mutations:end -->
+
+
+## State
+
+<!-- @vuese:Store:state:start -->
+|Name|Description|
+|---|---|
+|stateObject|stores the object|
+
+<!-- @vuese:Store:state:end -->
+
+
+",
+  "groupName": "BASIC",
+}
+`;
+
 exports[`Proper rendering of the table header 1`] = `
 Object {
   "data": "|Name|Type|Description|Default|

--- a/packages/markdown-render/__test__/index.test.ts
+++ b/packages/markdown-render/__test__/index.test.ts
@@ -80,6 +80,43 @@ test('Proper rendering of the table header', () => {
   expect(markdownRes).toMatchSnapshot()
 })
 
+test('Proper rendering of store', () => {
+  const res: ParserResult = {
+    name: 'Store',
+    getters: [
+      {
+        name: 'formattedObject',
+        describe: ['Returns a correctly formatted object']
+      }
+    ],
+    actions: [
+      {
+        name: 'fetchObject',
+        describe: ['Grabs the action from the API'],
+        argumentsDesc: ['the url to get']
+      }
+    ],
+    mutations: [
+      {
+        name: 'MUTATE_OBJECT',
+        describe: ['Set the object in the store'],
+        argumentsDesc: ['object with key/value to set']
+      }
+    ],
+    state: [
+      {
+        name: 'stateObject',
+        describe: ['stores the object']
+      }
+    ]
+  }
+  const render = new Render(res)
+  const renderRes: RenderResult = render.render()
+  const markdownRes = render.renderMarkdown() as MarkdownResult
+  expect(renderRes).toMatchSnapshot()
+  expect(markdownRes).toMatchSnapshot()
+})
+
 describe('Empty Components (without slots,methods,props,events) can be forced to be rendered', () => {
   test('Does not render an empty component by defaut', () => {
     const res: ParserResult = {

--- a/packages/markdown-render/lib/genMarkdownTpl.ts
+++ b/packages/markdown-render/lib/genMarkdownTpl.ts
@@ -18,6 +18,10 @@ export default function(parserRes: ParserResult) {
   templateStr += parserRes.mixIns ? genBaseTemplate('mixIns') : ''
   templateStr += parserRes.data ? genBaseTemplate('data') : ''
   templateStr += parserRes.watch ? genBaseTemplate('watch') : ''
+  templateStr += parserRes.getters ? genBaseTemplate('getters') : ''
+  templateStr += parserRes.actions ? genBaseTemplate('actions') : ''
+  templateStr += parserRes.mutations ? genBaseTemplate('mutations') : ''
+  templateStr += parserRes.state ? genBaseTemplate('state') : ''
 
   return !forceGenerate && original === templateStr ? '' : templateStr
 }

--- a/packages/markdown-render/lib/index.ts
+++ b/packages/markdown-render/lib/index.ts
@@ -63,7 +63,7 @@ export class Render {
         mixIns: ['MixIn'],
         data: ['Name', 'Type', 'Description', 'Default'],
         watch: ['Name', 'Description', 'Parameters'],
-        getters: ['Getter', 'Type', 'Description'],
+        getters: ['Getter', 'Description'],
         actions: ['Action', 'Description', 'Parameters'],
         mutations: ['Mutation', 'Description', 'Parameters'],
         state: ['Name', 'Description']
@@ -427,13 +427,6 @@ export class Render {
       for (let i = 0; i < getterConfig.length; i++) {
         if (getterConfig[i] === 'Getter') {
           row.push(getter.name)
-        } else if (getterConfig[i] === 'Type') {
-          if (getter.type) {
-            row.push(`\`${getter.type.join(' ')}\``)
-            row.push()
-          } else {
-            row.push('-')
-          }
         } else if (getterConfig[i] === 'Description') {
           if (getter.describe) {
             row.push(getter.describe.join(' '))

--- a/packages/markdown-render/lib/index.ts
+++ b/packages/markdown-render/lib/index.ts
@@ -7,7 +7,11 @@ import {
   DataResult,
   MethodResult,
   ComputedResult,
-  WatchResult
+  WatchResult,
+  GetterResult,
+  ActionResult,
+  MutationResult,
+  StateResult
 } from '@vuese/parser'
 import renderMarkdown, { MarkdownResult } from './renderMarkdown'
 
@@ -22,6 +26,10 @@ interface RenderOptions {
   mixIns: string[]
   data: string[]
   watch: string[]
+  getters: string[]
+  actions: string[]
+  mutations: string[]
+  state: string[]
 }
 
 export interface RenderResult {
@@ -33,6 +41,10 @@ export interface RenderResult {
   mixIns?: string
   data?: string
   watch?: string
+  getters?: string
+  actions?: string
+  mutations?: string
+  state?: string
 }
 
 export class Render {
@@ -50,7 +62,11 @@ export class Render {
         computed: ['Computed', 'Type', 'Description', 'From Store'],
         mixIns: ['MixIn'],
         data: ['Name', 'Type', 'Description', 'Default'],
-        watch: ['Name', 'Description', 'Parameters']
+        watch: ['Name', 'Description', 'Parameters'],
+        getters: ['Getter', 'Type', 'Description'],
+        actions: ['Action', 'Description', 'Parameters'],
+        mutations: ['Mutation', 'Description', 'Parameters'],
+        state: ['Name', 'Description']
       },
       this.options
     )
@@ -65,7 +81,11 @@ export class Render {
       mixIns,
       data,
       computed,
-      watch
+      watch,
+      getters,
+      actions,
+      mutations,
+      state
     } = this.parserResult
     let md: RenderResult = {}
     if (props) {
@@ -91,6 +111,18 @@ export class Render {
     }
     if (watch) {
       md.watch = this.watchRender(watch)
+    }
+    if (getters) {
+      md.getters = this.getterRender(getters)
+    }
+    if (actions) {
+      md.actions = this.actionRender(actions)
+    }
+    if (mutations) {
+      md.mutations = this.mutationRender(mutations)
+    }
+    if (state) {
+      md.state = this.stateRender(state)
     }
 
     return md
@@ -374,6 +406,121 @@ export class Render {
         } else if (watchConfig[i] === 'Parameters') {
           if (watch.argumentsDesc) {
             row.push(watch.argumentsDesc.join(' '))
+          } else {
+            row.push('-')
+          }
+        } else {
+          row.push('-')
+        }
+      }
+      code += this.renderTabelRow(row)
+    })
+
+    return code
+  }
+
+  getterRender(getterRes: GetterResult[]) {
+    const getterConfig = (this.options as RenderOptions).getters
+    let code = this.renderTabelHeader(getterConfig)
+    getterRes.forEach((getter: GetterResult) => {
+      const row: string[] = []
+      for (let i = 0; i < getterConfig.length; i++) {
+        if (getterConfig[i] === 'Getter') {
+          row.push(getter.name)
+        } else if (getterConfig[i] === 'Type') {
+          if (getter.type) {
+            row.push(`\`${getter.type.join(' ')}\``)
+            row.push()
+          } else {
+            row.push('-')
+          }
+        } else if (getterConfig[i] === 'Description') {
+          if (getter.describe) {
+            row.push(getter.describe.join(' '))
+          } else {
+            row.push('-')
+          }
+        } else {
+          row.push('-')
+        }
+      }
+      code += this.renderTabelRow(row)
+    })
+
+    return code
+  }
+
+  actionRender(actionRes: ActionResult[]) {
+    const actionConfig = (this.options as RenderOptions).actions
+    let code = this.renderTabelHeader(actionConfig)
+    actionRes.forEach((action: ActionResult) => {
+      const row: string[] = []
+      for (let i = 0; i < actionConfig.length; i++) {
+        if (actionConfig[i] === 'Action') {
+          row.push(action.name)
+        } else if (actionConfig[i] === 'Description') {
+          if (action.describe) {
+            row.push(action.describe.join(' '))
+          } else {
+            row.push('-')
+          }
+        } else if (actionConfig[i] === 'Parameters') {
+          if (action.argumentsDesc) {
+            row.push(action.argumentsDesc.join(' '))
+          } else {
+            row.push('-')
+          }
+        } else {
+          row.push('-')
+        }
+      }
+      code += this.renderTabelRow(row)
+    })
+
+    return code
+  }
+
+  mutationRender(mutationRes: MutationResult[]) {
+    const mutationConfig = (this.options as RenderOptions).mutations
+    let code = this.renderTabelHeader(mutationConfig)
+    mutationRes.forEach((mutation: MutationResult) => {
+      const row: string[] = []
+      for (let i = 0; i < mutationConfig.length; i++) {
+        if (mutationConfig[i] === 'Mutation') {
+          row.push(mutation.name)
+        } else if (mutationConfig[i] === 'Description') {
+          if (mutation.describe) {
+            row.push(mutation.describe.join(' '))
+          } else {
+            row.push('-')
+          }
+        } else if (mutationConfig[i] === 'Parameters') {
+          if (mutation.argumentsDesc) {
+            row.push(mutation.argumentsDesc.join(' '))
+          } else {
+            row.push('-')
+          }
+        } else {
+          row.push('-')
+        }
+      }
+      code += this.renderTabelRow(row)
+    })
+
+    return code
+  }
+
+  stateRender(stateRes: StateResult[]) {
+    const stateConfig = (this.options as RenderOptions).state
+    let code = this.renderTabelHeader(stateConfig)
+    stateRes.forEach((state: StateResult) => {
+      const row: string[] = []
+      for (let i = 0; i < stateConfig.length; i++) {
+        if (stateConfig[i] === 'Name') {
+          row.push(state.name)
+        } else if (stateConfig[i] === 'Description') {
+          if (state.describe) {
+            row.push(state.describe.join(' '))
           } else {
             row.push('-')
           }

--- a/packages/parser/__test__/__fixtures__/common.js
+++ b/packages/parser/__test__/__fixtures__/common.js
@@ -1,0 +1,10 @@
+export default {
+  data () {
+    return {
+      a: 1
+    }
+  },
+  props: {
+    a: String
+  }
+}

--- a/packages/parser/__test__/__fixtures__/store.js
+++ b/packages/parser/__test__/__fixtures__/store.js
@@ -1,0 +1,23 @@
+export default {
+    getters: {
+        // @vuese
+        // Returns a correctly formatted object
+        formattedObject(state) {}
+    },
+    actions: {
+        // @vuese
+        // Grabs the action from the API
+        // @arg the url to get
+        async fetchObject({ commit, state }, url) {}
+    },
+    mutations: {
+        // @vuese
+        // Set the object in the store
+        // @arg object with key/value to set
+        MUTATE_OBJECT(state, { key, value }) {}
+    },
+    state: {
+        // stores the object
+        stateObject: {}
+    }
+};

--- a/packages/parser/__test__/__snapshots__/parseJavascript.test.ts.snap
+++ b/packages/parser/__test__/__snapshots__/parseJavascript.test.ts.snap
@@ -40,6 +40,18 @@ Array [
 ]
 `;
 
+exports[`Correct handling of actions 1`] = `
+Array [
+  "Grabs the action from the API",
+]
+`;
+
+exports[`Correct handling of actions 2`] = `
+Array [
+  "the url to get",
+]
+`;
+
 exports[`Correct handling of events 1`] = `
 Array [
   "Triggered when clicked",
@@ -56,6 +68,12 @@ exports[`Correct handling of events 3`] = `Array []`;
 
 exports[`Correct handling of events 4`] = `undefined`;
 
+exports[`Correct handling of getters 1`] = `
+Array [
+  "Returns a correctly formatted object",
+]
+`;
+
 exports[`Correct handling of methods 1`] = `
 Array [
   "Do something",
@@ -65,6 +83,24 @@ Array [
 exports[`Correct handling of methods 2`] = `
 Array [
   "The first parameter is a Boolean value that represents...",
+]
+`;
+
+exports[`Correct handling of mutations 1`] = `
+Array [
+  "Set the object in the store",
+]
+`;
+
+exports[`Correct handling of mutations 2`] = `
+Array [
+  "object with key/value to set",
+]
+`;
+
+exports[`Correct handling of mutations 3`] = `
+Array [
+  "stores the object",
 ]
 `;
 

--- a/packages/parser/__test__/sfcToAST.test.ts
+++ b/packages/parser/__test__/sfcToAST.test.ts
@@ -3,16 +3,23 @@ import { sfcToAST, AstResult } from '@vuese/parser'
 import * as path from 'path'
 import * as fs from 'fs'
 
-function getAST(fileName: string): AstResult {
+function getAST(fileName: string, jsFile: boolean): AstResult {
   const p = path.resolve(__dirname, `./__fixtures__/${fileName}`)
   const source = fs.readFileSync(p, 'utf-8')
-  return sfcToAST(source)
+  return sfcToAST(source, { jsx: false }, jsFile)
 }
 
 test('The type of `jsAst` should be File', () => {
-  const sfc = getAST('common.vue')
+  const sfc = getAST('common.vue', false)
   expect(bt.isFile(sfc.jsAst as object)).toBe(true)
   expect(sfc.sourceType).toBe('js')
   expect((sfc.templateAst as any).type).toBe(1)
   expect((sfc.templateAst as any).tag).toBe('div')
+})
+
+test('The source type of `jsAst` is set to `js` if `jsFile` passed', () => {
+  const sfc = getAST('common.js', true)
+  expect(bt.isFile(sfc.jsAst as object)).toBe(true)
+  expect(sfc.sourceType).toBe('js')
+  expect(sfc.templateAst).toBe(undefined)
 })

--- a/packages/parser/lib/index.ts
+++ b/packages/parser/lib/index.ts
@@ -66,6 +66,11 @@ export interface EventResult {
   argumentsDesc?: string[]
 }
 
+export interface StateResult {
+  name: string
+  describe?: string[]
+}
+
 export interface MethodResult {
   name: string
   describe?: string[]
@@ -109,6 +114,24 @@ export interface SlotResult {
   target: 'template' | 'script'
 }
 
+export interface GetterResult {
+  name: string
+  type?: string[]
+  describe?: string[]
+}
+
+export interface ActionResult {
+  name: string
+  describe?: string[]
+  argumentsDesc?: string[]
+}
+
+export interface MutationResult {
+  name: string
+  describe?: string[]
+  argumentsDesc?: string[]
+}
+
 export interface ParserOptions {
   onProp?: {
     (propsRes: PropsResult): void
@@ -140,7 +163,20 @@ export interface ParserOptions {
   onWatch?: {
     (watch: WatchResult): void
   }
+  onState?: {
+    (stateRes: StateResult): void
+  }
+  onGetter?: {
+    (getterRes: MethodResult): void
+  }
+  onMutation?: {
+    (mutationRes: MethodResult): void
+  }
+  onAction?: {
+    (actionRes: MethodResult): void
+  }
   babelParserPlugins?: BabelParserPlugins
+  jsFile?: any
 }
 
 export interface ParserResult {
@@ -149,6 +185,10 @@ export interface ParserResult {
   slots?: SlotResult[]
   mixIns?: MixInResult[]
   methods?: MethodResult[]
+  getters?: MethodResult[]
+  mutations?: MethodResult[]
+  actions?: MethodResult[]
+  state?: StateResult[]
   computed?: ComputedResult[]
   data?: DataResult[]
   watch?: WatchResult[]
@@ -160,7 +200,8 @@ export function parser(
   source: string,
   options: ParserOptions = {}
 ): ParserResult {
-  const astRes = sfcToAST(source, options.babelParserPlugins)
+  const astRes = sfcToAST(source, options.babelParserPlugins, options.jsFile)
+
   const res: ParserResult = {}
   const defaultOptions: ParserOptions = {
     onName(name: string) {
@@ -183,6 +224,18 @@ export function parser(
     },
     onMethod(methodRes: MethodResult) {
       ;(res.methods || (res.methods = [])).push(methodRes)
+    },
+    onGetter(getterRes: MethodResult) {
+      ;(res.getters || (res.getters = [])).push(getterRes)
+    },
+    onAction(actionRes: MethodResult) {
+      ;(res.actions || (res.actions = [])).push(actionRes)
+    },
+    onMutation(mutationRes: MethodResult) {
+      ;(res.mutations || (res.mutations = [])).push(mutationRes)
+    },
+    onState(stateRes: StateResult) {
+      ;(res.state || (res.state = [])).push(stateRes)
     },
     onComputed(computedRes: ComputedResult) {
       ;(res.computed || (res.computed = [])).push(computedRes)

--- a/packages/parser/lib/index.ts
+++ b/packages/parser/lib/index.ts
@@ -116,7 +116,6 @@ export interface SlotResult {
 
 export interface GetterResult {
   name: string
-  type?: string[]
   describe?: string[]
 }
 
@@ -167,13 +166,13 @@ export interface ParserOptions {
     (stateRes: StateResult): void
   }
   onGetter?: {
-    (getterRes: MethodResult): void
+    (getterRes: GetterResult): void
   }
   onMutation?: {
-    (mutationRes: MethodResult): void
+    (mutationRes: MutationResult): void
   }
   onAction?: {
-    (actionRes: MethodResult): void
+    (actionRes: ActionResult): void
   }
   babelParserPlugins?: BabelParserPlugins
   jsFile?: any
@@ -185,9 +184,9 @@ export interface ParserResult {
   slots?: SlotResult[]
   mixIns?: MixInResult[]
   methods?: MethodResult[]
-  getters?: MethodResult[]
-  mutations?: MethodResult[]
-  actions?: MethodResult[]
+  getters?: GetterResult[]
+  mutations?: MutationResult[]
+  actions?: ActionResult[]
   state?: StateResult[]
   computed?: ComputedResult[]
   data?: DataResult[]

--- a/packages/parser/lib/parseJavascript.ts
+++ b/packages/parser/lib/parseJavascript.ts
@@ -81,14 +81,17 @@ export function parseJavascript(ast: bt.File, options: ParserOptions = {}) {
             handleMethod(path, onGetter)
           }
 
+          // Processing store actions
           if (onAction && isVueOption(path, 'actions')) {
             handleMethod(path, onAction)
           }
 
+          // Processing store mutations
           if (onMutation && isVueOption(path, 'mutations')) {
             handleMethod(path, onMutation)
           }
 
+          // Processing store state
           if (onState && isVueOption(path, 'state')) {
             const properties = (path.node.value as bt.ObjectExpression)
               .properties as (bt.ObjectMethod | bt.ObjectProperty)[]

--- a/packages/parser/lib/sfcToAST.ts
+++ b/packages/parser/lib/sfcToAST.ts
@@ -23,7 +23,7 @@ export function sfcToAST(
   const res: AstResult = {}
 
   if ((sfc.script && sfc.script.content) || jsFile) {
-    res.sourceType = sfc.script ? sfc.script.lang : 'js'
+    res.sourceType = sfc.script && sfc.script.lang ? sfc.script.lang : 'js'
     res.jsAst = babelParse(jsFile ? source : sfc.script.content, {
       sourceType: 'module',
       plugins

--- a/packages/parser/lib/sfcToAST.ts
+++ b/packages/parser/lib/sfcToAST.ts
@@ -15,14 +15,16 @@ export interface AstResult {
 
 export function sfcToAST(
   source: string,
-  babelParserPlugins?: BabelParserPlugins
+  babelParserPlugins?: BabelParserPlugins,
+  jsFile?: boolean
 ): AstResult {
   const plugins = getBabelParserPlugins(babelParserPlugins)
   const sfc = parseComponent(source)
   const res: AstResult = {}
-  if (sfc.script && sfc.script.content) {
-    res.sourceType = sfc.script.lang || 'js'
-    res.jsAst = babelParse(sfc.script.content, {
+
+  if ((sfc.script && sfc.script.content) || jsFile) {
+    res.sourceType = sfc.script ? sfc.script.lang : 'js'
+    res.jsAst = babelParse(jsFile ? source : sfc.script.content, {
       sourceType: 'module',
       plugins
     })


### PR DESCRIPTION
This PR adds the ability for Vuese to be used with the store.js file and any mixins. I didn't set these to be automatically included, so this functionality would be completely optional. Adding `**/*.js` to the `included` will allow these to be picked up.

I am not too familiar with TypeScript, so if there a better way to accomplish any of this, or if you see anything you would like changed, let me know and I will update this PR.

Thanks!