### PR TITLE
feat: Optimize the opening action of the browser

### DIFF
--- a/packages/cli/lib/server.ts
+++ b/packages/cli/lib/server.ts
@@ -4,8 +4,30 @@ import getPort from 'get-port'
 import open from 'open'
 import Log from 'log-horizon'
 import { CliOptions } from '.'
+import fs from 'fs-extra'
 
 const logger = Log.create()
+
+function getFirstPath(config: CliOptions): string {
+  const entryPath = path.resolve(`${config.outDir}/index.html`)
+  const reg = /(?:[\s\S]+)sidebar\:([\s\S]+)\}\)/
+  const entrySourceStr: string = fs.readFileSync(entryPath, 'utf-8') || ''
+  try {
+    const regRes = (entrySourceStr as any).match(reg)[1]
+    const routesConfig = new Function(`return ${regRes}`)()
+    const firstRoute = routesConfig.reduce((p: string, v: any, i: number) => {
+      if (i === 0) {
+        const { links } = v
+        return links[0] && links[0].link
+      }
+    }, '')
+    // Read the first preview configuration injected when opening the browser.
+    return `#${firstRoute}`
+  } catch (e) {
+    // If there's an error, follow the previous logic.
+    return ''
+  }
+}
 
 export default async (config: CliOptions) => {
   const http = require('http')
@@ -18,7 +40,7 @@ export default async (config: CliOptions) => {
   const port = config.port || (await getPort({ port: 5000 }))
 
   server.listen(port, config.host, () => {
-    const addr = `http://${config.host}:${port}/`
+    const addr = `http://${config.host}:${port}/${getFirstPath(config)}`
     logger.success(`Server running at ${addr}`)
     if (config.open) open(addr)
   })


### PR DESCRIPTION
Hi there, When I use @vuese/cli I have found some points that we can optimize👇

**Steps to reproduce：**
- `vuese gen` & `vuese serve --open`
- The default link is `http://127.0.0.1:5000/#/`
- This will show a 404 page, and we should actually open the first valid link by default


<img height="400" alt="before" src="https://user-images.githubusercontent.com/22092110/86537129-55a52880-bf1f-11ea-8af9-0c601d0a374c.png">

Currently I'm using  @vuese/cli  and I hope I can contribute to it.
- With this pr, the first valid link opened
- [repo link](https://github.com/screetBloom/vuese-parser-data)

<img height="400" alt="after" src="https://user-images.githubusercontent.com/22092110/86537136-66ee3500-bf1f-11ea-8422-cdc4cf8d025f.png">


<br>
<br>
<br>

This is my first contribution to vuese, **I am eager to get this merged** . Thx~
@HcySunYang   @IWANABETHATGUY

<br>
<br>




