### PR TITLE
Support "docs" custom block

### DIFF
--- a/packages/markdown-render/lib/genMarkdownTpl.ts
+++ b/packages/markdown-render/lib/genMarkdownTpl.ts
@@ -18,6 +18,7 @@ export default function(parserRes: ParserResult): string {
   templateStr += parserRes.mixIns ? genBaseTemplate('mixIns') : ''
   templateStr += parserRes.data ? genBaseTemplate('data') : ''
   templateStr += parserRes.watch ? genBaseTemplate('watch') : ''
+  templateStr += parserRes.extraDocs ? parserRes.extraDocs : ''
 
   return !forceGenerate && original === templateStr ? '' : templateStr
 }

--- a/packages/parser/lib/index.ts
+++ b/packages/parser/lib/index.ts
@@ -156,6 +156,7 @@ export interface ParserResult {
   watch?: WatchResult[]
   name?: string
   componentDesc?: CommentResult
+  extraDocs?: string
 }
 
 export function parser(
@@ -177,28 +178,28 @@ export function parser(
       res.componentDesc = desc
     },
     onProp(propsRes: PropsResult) {
-      ;(res.props || (res.props = [])).push(propsRes)
+      ; (res.props || (res.props = [])).push(propsRes)
     },
     onEvent(eventsRes: EventResult) {
-      ;(res.events || (res.events = [])).push(eventsRes)
+      ; (res.events || (res.events = [])).push(eventsRes)
     },
     onSlot(slotRes: SlotResult) {
-      ;(res.slots || (res.slots = [])).push(slotRes)
+      ; (res.slots || (res.slots = [])).push(slotRes)
     },
     onMixIn(mixInRes: MixInResult) {
-      ;(res.mixIns || (res.mixIns = [])).push(mixInRes)
+      ; (res.mixIns || (res.mixIns = [])).push(mixInRes)
     },
     onMethod(methodRes: MethodResult) {
-      ;(res.methods || (res.methods = [])).push(methodRes)
+      ; (res.methods || (res.methods = [])).push(methodRes)
     },
     onComputed(computedRes: ComputedResult) {
-      ;(res.computed || (res.computed = [])).push(computedRes)
+      ; (res.computed || (res.computed = [])).push(computedRes)
     },
     onData(dataRes: DataResult) {
-      ;(res.data || (res.data = [])).push(dataRes)
+      ; (res.data || (res.data = [])).push(dataRes)
     },
     onWatch(watchRes: WatchResult) {
-      ;(res.watch || (res.watch = [])).push(watchRes)
+      ; (res.watch || (res.watch = [])).push(watchRes)
     }
   }
 
@@ -210,5 +211,9 @@ export function parser(
   if (astRes.templateAst) {
     parseTemplate(astRes.templateAst, seenEvent, finallyOptions)
   }
+  if (astRes.docSource) {
+    res.extraDocs = astRes.docSource;
+  }
+
   return res
 }

--- a/packages/parser/lib/index.ts
+++ b/packages/parser/lib/index.ts
@@ -178,28 +178,28 @@ export function parser(
       res.componentDesc = desc
     },
     onProp(propsRes: PropsResult) {
-      ; (res.props || (res.props = [])).push(propsRes)
+      ;(res.props || (res.props = [])).push(propsRes)
     },
     onEvent(eventsRes: EventResult) {
-      ; (res.events || (res.events = [])).push(eventsRes)
+      ;(res.events || (res.events = [])).push(eventsRes)
     },
     onSlot(slotRes: SlotResult) {
-      ; (res.slots || (res.slots = [])).push(slotRes)
+      ;(res.slots || (res.slots = [])).push(slotRes)
     },
     onMixIn(mixInRes: MixInResult) {
-      ; (res.mixIns || (res.mixIns = [])).push(mixInRes)
+      ;(res.mixIns || (res.mixIns = [])).push(mixInRes)
     },
     onMethod(methodRes: MethodResult) {
-      ; (res.methods || (res.methods = [])).push(methodRes)
+      ;(res.methods || (res.methods = [])).push(methodRes)
     },
     onComputed(computedRes: ComputedResult) {
-      ; (res.computed || (res.computed = [])).push(computedRes)
+      ;(res.computed || (res.computed = [])).push(computedRes)
     },
     onData(dataRes: DataResult) {
-      ; (res.data || (res.data = [])).push(dataRes)
+      ;(res.data || (res.data = [])).push(dataRes)
     },
     onWatch(watchRes: WatchResult) {
-      ; (res.watch || (res.watch = [])).push(watchRes)
+      ;(res.watch || (res.watch = [])).push(watchRes)
     }
   }
 

--- a/packages/parser/lib/sfcToAST.ts
+++ b/packages/parser/lib/sfcToAST.ts
@@ -15,6 +15,7 @@ export interface AstResult {
   templateAst?: object
   jsSource: string
   templateSource: string
+  docSource: string
 }
 
 export function sfcToAST(
@@ -25,7 +26,7 @@ export function sfcToAST(
 ): AstResult {
   const plugins = getBabelParserPlugins(babelParserPlugins)
   const sfc = parseComponent(source)
-  const res: AstResult = { jsSource: '', templateSource: '' }
+  const res: AstResult = { jsSource: '', templateSource: '', docSource: '' }
   if (sfc.script || jsFile) {
     if (sfc.script && (!sfc.script.content && sfc.script.src)) {
       // Src Imports
@@ -69,6 +70,14 @@ export function sfcToAST(
       comments: true
     }).ast
   }
+
+  if (sfc.customBlocks && sfc.customBlocks.length) {
+    const docsBlock = sfc.customBlocks.find((block: Record<string, any>) => block.type === 'docs');
+    if (docsBlock) {
+      res.docSource = docsBlock.content || ''
+    }
+  }
+
   return res
 }
 


### PR DESCRIPTION
This PR renders the contents of `<docs></docs>` [custom blocks](https://vue-loader.vuejs.org/spec.html#custom-blocks) at the end of the markdown files. 

![Screen Shot 2020-08-07 at 2 59 01 PM](https://user-images.githubusercontent.com/611996/89683688-9a293880-d8be-11ea-88d1-09ef379fe007.png)
