### PR TITLE
Fix issue building on node v12.18.2

### DIFF
--- a/packages/cli/lib/preview.ts
+++ b/packages/cli/lib/preview.ts
@@ -1,4 +1,5 @@
-import { EventEmitter } from 'events'
+import * as events from 'events';
+const { EventEmitter } = events;
 import path from 'path'
 import carlo from 'carlo'
 import fs from 'fs-extra'


### PR DESCRIPTION
Just a small fix. This fixes this error when building on my machine with rollup:

`[!] Error: 'EventEmitter' is not exported by ../node_modules/events/events.js`

See https://github.com/rollup/rollup/issues/481

Thanks!
