### PR TITLE
Add docuteOptions to pass options into docute

### DIFF
--- a/packages/cli/lib/genDocute.ts
+++ b/packages/cli/lib/genDocute.ts
@@ -18,7 +18,8 @@ export default async (config: CliOptions): Promise<void> => {
       configOptions: {
         components,
         title: config.title,
-        markdownDir: config.markdownDir
+        markdownDir: config.markdownDir,
+        docuteOptions: config.docuteOptions
       }
     })
     logger.success('Generated successfully')

--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -39,6 +39,7 @@ export type CliOptions = {
   port: number
   host: string
   keepFolderStructure: boolean
+  docuteOptions: object
 }
 type PartialCliOptions = Partial<CliOptions>
 

--- a/packages/cli/lib/templates/docute/sao.js
+++ b/packages/cli/lib/templates/docute/sao.js
@@ -1,5 +1,5 @@
 module.exports = options => {
-  const { title, components, markdownDir } = options
+  const { title, components, markdownDir, docuteOptions } = options
   const groupsObjs = {}
   const groups = []
   components.forEach(c => {
@@ -35,8 +35,12 @@ module.exports = options => {
     data(answers) {
       return {
         title: title || answers.title,
-        groupsStr: JSON.stringify(groups),
-        markdownDir
+        markdownDir,
+        docuteConfig: JSON.stringify({
+          target: '#docute',
+          sidebar: groups,
+          ...(docuteOptions || {})
+        })
       }
     }
   }

--- a/packages/cli/lib/templates/docute/sao.js
+++ b/packages/cli/lib/templates/docute/sao.js
@@ -1,5 +1,5 @@
 module.exports = options => {
-  const { title, components, markdownDir, docuteOptions } = options
+  const { title, components, markdownDir, docuteOptions = {} } = options
   const groupsObjs = {}
   const groups = []
   components.forEach(c => {
@@ -37,9 +37,9 @@ module.exports = options => {
         title: title || answers.title,
         markdownDir,
         docuteConfig: JSON.stringify({
+          ...docuteOptions,
           target: '#docute',
-          sidebar: groups,
-          ...(docuteOptions || {})
+          sidebar: [...docuteOptions.sidebar, ...groups]
         })
       }
     }

--- a/packages/cli/lib/templates/docute/template/index.html
+++ b/packages/cli/lib/templates/docute/template/index.html
@@ -10,10 +10,7 @@
     <div id="docute"></div>
     <script src="https://cdn.jsdelivr.net/npm/docute@4/dist/docute.js"></script>
     <script>
-      new Docute({
-        target: '#docute',
-        sidebar: JSON.parse('<%= groupsStr %>'.replace(/\&\#34\;/g, '"'))
-      })
+      new Docute(JSON.parse('<%= docuteConfig %>'.replace(/\&\#34\;/g, '"')))
     </script>
   </body>
 </html>


### PR DESCRIPTION
This allows more flexibility to add docute options to the output. 

Example vuese.config.js:
```js
module.exports = {
  docuteOptions: {
    darkThemeToggler: true
  }
};
```

Additionally, if `docuteOptions.sidebar` exists, the sidebars will be merged with the custom content first, then vuese sidebar below it. 

<img width="353" alt="Screen Shot 2020-08-07 at 9 35 19 PM" src="https://user-images.githubusercontent.com/611996/89700689-e93e9000-d8f5-11ea-8146-5d856be89732.png">

In this screenshot, the "Plugins" section is defined like this in the config:

```js
module.exports = {
  docuteOptions: {
    sidebar: [
      {
        title: 'Plugins',
        links: [
          {
            title: 'EvMenu',
            link: '/plugins/EvMenu'
          }
        ]
      }
    ]
  }
};
```



Thanks!