### PR TITLE
update sao to above 2.0.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,7 +47,7 @@
     "marked": "^0.7.0",
     "open": "^6.4.0",
     "prismjs": "^1.15.0",
-    "sao": "^0.22.17",
+    "sao": "^2.0.0",
     "serve-handler": "^5.0.7"
   },
   "gitHead": "2bc1b0691aaf9480fa6fc0ad59ff1bc991b81efe"


### PR DESCRIPTION
This PR updates `sao` to above `2.0.0` to address security vulnerabilities of `dot-prop` < `5.1.1`, a sub-dependency of `sao`

Package `sao` has a sub-dependency on `dot-prop`.  `dot-prop` has a vulnerability that is fixed in version `5.2.0+`.

Unfortunately, `sao`'s lastest version is `v2.0.0-beta.1`.  Not sure if there is another NPM magical way of handling this, but updating this `package.json` is all that I can think of.

Hope this helps 😄 

```
High            Prototype Pollution                                                                                                   
Package         dot-prop                                                                                                              
Patched in      >=5.1.1                                                                                                               
Dependency of   @vuese/cli [dev]                                                                                                      
Path            @vuese/cli > sao > conf > dot-prop                                                                                    
More info       https://npmjs.com/advisories/1213                                                                                     
                                                                                                                                      
High            Prototype Pollution                                                                                                   
Package         dot-prop                                                                                                              
Patched in      >=5.1.1                                                                                                               
Dependency of   @vuese/cli [dev]                                                                                                      
Path            @vuese/cli > sao > update-notifier > configstore > dot-prop                                                           
More info       https://npmjs.com/advisories/1213   
```
```
# npm ls dot-prop
...
+-- @vue/cli-service@4.4.6
| `-- @intervolga/optimize-cssnano-plugin@1.0.6
|   `-- cssnano-preset-default@4.0.7
|     +-- postcss-merge-longhand@4.0.11
|     | `-- stylehacks@4.0.3
|     |   `-- postcss-selector-parser@3.1.2
|     |     `-- dot-prop@5.2.0  deduped
|     +-- postcss-merge-rules@4.0.3
|     | `-- postcss-selector-parser@3.1.2
|     |   `-- dot-prop@5.2.0  deduped
|     `-- postcss-minify-selectors@4.0.2
|       `-- postcss-selector-parser@3.1.2
|         `-- dot-prop@5.2.0  deduped
+-- @vuese/cli@2.14.0
| `-- sao@0.22.17
|   +-- conf@1.4.0
|   | `-- dot-prop@4.2.0 
|   `-- update-notifier@2.5.0
|     `-- configstore@3.1.2
|       `-- dot-prop@4.2.0 
`-- nodemon@2.0.4
  `-- update-notifier@4.1.0
    `-- configstore@5.0.1
      `-- dot-prop@5.2.0 
```