### PR TITLE
fix: use 7.3 @babel/types to match ts@3.8

### DIFF
--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -19,7 +19,7 @@
     "@babel/generator": "^7.12.10",
     "@babel/parser": "^7.12.0",
     "@babel/traverse": "^7.12.0",
-    "@babel/types": "^7.12.0",
+    "@babel/types": "^7.3.4",
     "vue-template-compiler": "^2.6.11"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -336,7 +336,7 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.12.0", "@babel/types@^7.12.10", "@babel/types@^7.12.11", "@babel/types@^7.12.12", "@babel/types@^7.12.7":
+"@babel/types@^7.12.10", "@babel/types@^7.12.11", "@babel/types@^7.12.12", "@babel/types@^7.12.7":
   version "7.12.12"
   resolved "https://registry.npm.taobao.org/@babel/types/download/@babel/types-7.12.12.tgz?cache=0&sync_timestamp=1608732917055&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40babel%2Ftypes%2Fdownload%2F%40babel%2Ftypes-7.12.12.tgz#4608a6ec313abbd87afa55004d373ad04a96c299"
   integrity sha1-Rgim7DE6u9h6+lUATTc60EqWwpk=


### PR DESCRIPTION


typescript@3.8 can't use @babel/types@^7.12


### 1.yarn run test

![image](https://user-images.githubusercontent.com/22092110/103264061-8654af00-49e4-11eb-987d-e99f06c69f00.png)



### 2.yarn run build
![image](https://user-images.githubusercontent.com/22092110/103264140-ca47b400-49e4-11eb-919f-32d2c2c72d37.png)


<br>
<br>
<br>
<br>




