### PR TITLE
fix from invalid table markdown code

### DIFF
--- a/packages/markdown-render/lib/genMarkdownTpl.ts
+++ b/packages/markdown-render/lib/genMarkdownTpl.ts
@@ -24,7 +24,7 @@ export default function(parserRes: ParserResult): string {
 
 function genBaseTemplate(label: string): string {
   let str = `## ${upper(label)}\n\n`
-  str += `<!-- @vuese:[name]:${label}:start -->\n`
+  str += `<!-- @vuese:[name]:${label}:start -->\n\n`
   str += `<!-- @vuese:[name]:${label}:end -->\n\n`
   return str
 }

--- a/packages/markdown-render/lib/renderMarkdown.ts
+++ b/packages/markdown-render/lib/renderMarkdown.ts
@@ -46,7 +46,7 @@ export default function(
       )
       str = str.replace(currentHtmlCommentRE, (s, c1, c2) => {
         if (renderRes[type]) {
-          let code = `<!-- @vuese:${c1}:${c2}:start -->\n`
+          let code = `<!-- @vuese:${c1}:${c2}:start -->\n\n`
           code += renderRes[type]
           code += `\n<!-- @vuese:${c1}:${c2}:end -->\n`
           return code


### PR DESCRIPTION
As reported here https://github.com/vuese/vuese/issues/92
the vuese html comment right before the table markdown break most markdown interpreters.

This add a newline after each html comments, this way markdown will be well interpreted.