### PR TITLE
Add newline before table markdown

### DIFF
--- a/packages/markdown-render/__test__/__snapshots__/index.test.ts.snap
+++ b/packages/markdown-render/__test__/__snapshots__/index.test.ts.snap
@@ -57,6 +57,7 @@ This is a description of the component
 ## Props
 
 <!-- @vuese:MyComponent:props:start -->
+
 |Name|Description|Type|Required|Default|
 |---|---|---|---|---|
 |someProp|Represents the direction of the arrow|\`TOP\` / \`BOTTOM\`|\`true\`|\`TOP\`|
@@ -67,6 +68,7 @@ This is a description of the component
 ## Events
 
 <!-- @vuese:MyComponent:events:start -->
+
 |Event Name|Description|Parameters|
 |---|---|---|
 |click|Triggered when clicked|a boolean value|
@@ -77,6 +79,7 @@ This is a description of the component
 ## Slots
 
 <!-- @vuese:MyComponent:slots:start -->
+
 |Name|Description|Default Slot Content|
 |---|---|---|
 |header|Table header|\`<th>{{title}}</th>\`|
@@ -87,6 +90,7 @@ This is a description of the component
 ## Methods
 
 <!-- @vuese:MyComponent:methods:start -->
+
 |Method|Description|Parameters|
 |---|---|---|
 |clear|Clear form|a boolean value|
@@ -97,6 +101,7 @@ This is a description of the component
 ## MixIns
 
 <!-- @vuese:MyComponent:mixIns:start -->
+
 |MixIn|
 |---|
 |MixIn|
@@ -107,6 +112,7 @@ This is a description of the component
 ## Data
 
 <!-- @vuese:MyComponent:data:start -->
+
 |Name|Type|Description|Default|
 |---|---|---|---|
 |someVariable|\`String\`|Does something|-|
@@ -117,6 +123,7 @@ This is a description of the component
 ## Watch
 
 <!-- @vuese:MyComponent:watch:start -->
+
 |Name|Description|Parameters|
 |---|---|---|
 |question|Something about a question|a string value|

--- a/packages/markdown-render/lib/genMarkdownTpl.ts
+++ b/packages/markdown-render/lib/genMarkdownTpl.ts
@@ -24,7 +24,7 @@ export default function(parserRes: ParserResult): string {
 
 function genBaseTemplate(label: string): string {
   let str = `## ${upper(label)}\n\n`
-  str += `<!-- @vuese:[name]:${label}:start -->\n`
+  str += `<!-- @vuese:[name]:${label}:start -->\n\n`
   str += `<!-- @vuese:[name]:${label}:end -->\n\n`
   return str
 }

--- a/packages/markdown-render/lib/renderMarkdown.ts
+++ b/packages/markdown-render/lib/renderMarkdown.ts
@@ -46,7 +46,7 @@ export default function(
       )
       str = str.replace(currentHtmlCommentRE, (s, c1, c2) => {
         if (renderRes[type]) {
-          let code = `<!-- @vuese:${c1}:${c2}:start -->\n`
+          let code = `<!-- @vuese:${c1}:${c2}:start -->\n\n`
           code += renderRes[type]
           code += `\n<!-- @vuese:${c1}:${c2}:end -->\n`
           return code


### PR DESCRIPTION
As stated here https://github.com/vuese/vuese/issues/92
the html comment vuese add before table markdown break the rendering on most markdown interpreters.

I've added a newline solving this issue.