### PR TITLE
allow setting parserOptions in cli config

### DIFF
--- a/packages/cli/lib/genMarkdown.ts
+++ b/packages/cli/lib/genMarkdown.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import fg from 'fast-glob'
 import fs from 'fs-extra'
 import Log from 'log-horizon'
-import { CliOptions } from '.'
+import { CliOptions, getConfig } from '.'
 import { parser } from '@vuese/parser'
 import Render from '@vuese/markdown-render'
 
@@ -45,11 +45,12 @@ export default async (config: CliOptions): MarkdownResult => {
     const abs = path.resolve(p)
     const source = await fs.readFile(abs, 'utf-8')
     try {
-      const parserRes = parser(source, {
+      const { parserOptions } = await getConfig({});
+      const parserRes = parser(source, Object.assign({
         babelParserPlugins,
         basedir: path.dirname(abs),
         jsFile: abs.endsWith('.js')
-      })
+      }, parserOptions))
       const r = new Render(parserRes)
       const markdownRes = r.renderMarkdown()
 

--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -1,7 +1,7 @@
 import cac from 'cac'
 import JoyCon from 'joycon'
 import fs from 'fs-extra'
-import { BabelParserPlugins } from '@vuese/parser'
+import { BabelParserPlugins, ParserOptions } from '@vuese/parser'
 import Log from 'log-horizon'
 import preview from './preview'
 import genDocute from './genDocute'
@@ -38,11 +38,12 @@ export type CliOptions = {
   open: boolean
   port: number
   host: string
-  keepFolderStructure: boolean
+  keepFolderStructure: boolean,
+  parserOptions: ParserOptions
 }
 type PartialCliOptions = Partial<CliOptions>
 
-async function getConfig(
+export async function getConfig(
   flags: PartialCliOptions
 ): Promise<Partial<CliOptions>> {
   const { path, data } = await joycon.load([
@@ -59,7 +60,8 @@ async function getConfig(
     markdownDir: 'components',
     markdownFile: '',
     host: '127.0.0.1',
-    keepFolderStructure: false
+    keepFolderStructure: false,
+    parserOptions: {}
   }
   if (path) Object.assign(config, data, flags)
   Object.assign(config, flags || {})


### PR DESCRIPTION
This allows setting `parserOptions` in the CLI config which get passed to the parser.

The reason I need this is related to [this note](https://vuese.github.io/website/cli/#sync-event) about `.sync` events: 

> But for users, they don't care about such events, so we deliberately don't include such events in the generated documentation.

My users will care about having these events documented. As a result, I need to have the ability to put `parserOptions: { includeSyncEvent: true }` in my config so that the parser will include them when running the CLI.